### PR TITLE
Update e1-41.md

### DIFF
--- a/solutions_sipser/e1-41.md
+++ b/solutions_sipser/e1-41.md
@@ -27,7 +27,7 @@ We construct a machine $$M_S = (Q_S, \Sigma, \delta_S, q_{0S}, F_S)$$ that accep
 
 Let $$Q_S = \set{p_A, p_B} \times Q_A \times Q_B$$.
 Take $$q_{0S} = (p_A, q_{0A}, q_{0B})$$.
-Take $$F_S = \set{p_A, p_B} \times F_A \times F_B$$.
+Take $$F_S = \set{p_A} \times F_A \times F_B$$.
 
 
 


### PR DESCRIPTION
At "Take $$F_S = \set{p_A, p_B} \times F_A \times F_B$$", I do not think this is right because it does not respect the ordering in which digits are being read by your DFA. If you start computing some string y=a_1 b_1 ... a_k b_k, then on consuming an a_i you will be leaving a state of the form (p_A,r_a,r_b) and entering a state of the form (p_B,t_a,t_b) and likewise something similar happens for when your DFA consumes a b_i character from y. So on the final character consumed when a string is going to be accepted you must be at a state of the form (p_B,u_a,u_b), since you will be reading a character of the form b_j from y, the transition upon consuming this character leads to a state of the form (p_A,v_a,v_b) and never one with a first coordinate of p_B.